### PR TITLE
support recent interface changes to enable new config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ relations:
 
 Using Juju 2.4 or later:
 
-```
+```bash
 juju deploy cs:canonical-kubernetes --overlay ./k8s-vsphere-overlay.yaml
 juju trust vsphere-integrator
 ```
@@ -33,7 +33,7 @@ juju trust vsphere-integrator
 To deploy with earlier versions of Juju, you will need to provide the cloud
 credentials via the `credentials` charm config option:
 
-```
+```bash
 cat <<EOJ > /path/to/cloud.json
 {
   "vsphere_ip": "a.b.c.d",
@@ -55,8 +55,15 @@ The only required option is `datastore`, as it is not included in the Juju
 credential that this charm relies on. By default, this is set to *datastore1*.
 This can be changed with:
 
-```
+```bash
 juju config vsphere-integrator datastore='mydatastore'
+```
+
+You may also configure a *folder* and *resource pool path* for this charm.
+Details about these options can be found in the [vmware documentation][]:
+
+```bash
+juju config vsphere-integrator folder='juju-kubernetes' respool_path='foo'
 ```
 
 As mentioned in the **Usage** section, `credentials` may be set with a
@@ -66,20 +73,20 @@ other methods of specifying credentials for this charm.
 If `credentials` is empty, there are config options for each key that
 constitute a Juju credential. These can be set with:
 
-```
+```bash
 juju config vsphere-integrator \
   vsphere_ip='a.b.c.d' \
   user='joe' \
   password='passw0rd' \
   datacenter='dc0'
 ```
+
 >Note: If any of the credential config options are set, they must all be set.
 
 When all of the credential config options are empty, this charm will fall
 back to the credential data it received with `juju trust vsphere-integrator`.
 
-
-# Resource Usage Note
+## Resource Usage Note
 
 By relating to this charm, other charms can directly allocate resources, such
 as PersistentDisk volumes, which could lead to cloud charges and count against
@@ -89,17 +96,16 @@ they show up in Juju's status or GUI.  It is therefore up to the operator to
 manually delete these resources when they are no longer needed, using the
 vCenter console or API.
 
-
-# Examples
+## Examples
 
 Following are some examples using vSphere integration with CDK.
 
-## Creating a pod with a PersistentDisk-backed volume
+### Creating a pod with a PersistentDisk-backed volume
 
 This script creates a busybox pod with a persistent volume claim backed by
 vSphere's PersistentDisk.
 
-```sh
+```bash
 #!/bin/bash
 
 # create a storage class using the `kubernetes.io/vsphere-volume` provisioner
@@ -156,3 +162,4 @@ EOY
 
 [interface]: https://github.com/juju-solutions/interface-vsphere-integration
 [Canonical Kubernetes]: https://jujucharms.com/canonical-kubernetes
+[vmware documentation]: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/existing.html

--- a/config.yaml
+++ b/config.yaml
@@ -37,3 +37,14 @@ options:
       persistent volume claims. Defaults to 'datastore1'.
     type: string
     default: "datastore1"
+  folder:
+    description: |
+      Virtual center VM folder path under the datacenter. Defaults to 'juju-kubernetes'.
+      This value must not be empty.
+    type: string
+    default: "juju-kubernetes"
+  respool_path:
+    description: |
+      Path to resource pool under the datacenter.
+    type: string
+    default: ""

--- a/reactive/vsphere.py
+++ b/reactive/vsphere.py
@@ -1,5 +1,6 @@
 from charms.reactive import (
     hook,
+    is_flag_set,
     when_all,
     when_any,
     when_not,
@@ -11,32 +12,56 @@ from charms.reactive.relations import endpoint_from_name
 from charms import layer
 
 
-@when_any('config.changed.credentials')
+@when_any('config.changed.credentials',
+          'config.changed.vsphere_ip',
+          'config.changed.user',
+          'config.changed.password',
+          'config.changed.datacenter')
 def update_creds():
     clear_flag('charm.vsphere.creds.set')
 
 
+@when_any('config.changed.datastore',
+          'config.changed.folder',
+          'config.changed.respool_path')
+def update_config():
+    clear_flag('charm.vsphere.config.set')
+
+
 @when_not('charm.vsphere.creds.set')
-def get_creds():
-    toggle_flag('charm.vsphere.creds.set', layer.vsphere.get_credentials())
+def manage_creds():
+    toggle_flag('charm.vsphere.creds.set', layer.vsphere.save_credentials())
 
 
-@when_all('charm.vsphere.creds.set')
+@when_not('charm.vsphere.config.set')
+def manage_config():
+    toggle_flag('charm.vsphere.config.set', layer.vsphere.get_vsphere_config())
+
+
+@when_all('charm.vsphere.creds.set',
+          'charm.vsphere.config.set')
 @when_not('endpoint.clients.requests-pending')
 def no_requests():
     layer.status.active('ready')
 
 
 @when_all('charm.vsphere.creds.set',
+          'charm.vsphere.config.set',
+          'endpoint.clients.joined')
+@when_any('config.changed',
           'endpoint.clients.requests-pending')
 def handle_requests():
     clients = endpoint_from_name('clients')
-    for request in clients.requests:
+    config_change = is_flag_set('config.changed')
+    requests = clients.all_requests if config_change else clients.new_requests
+    for request in requests:
         layer.status.maintenance(
             'granting request for {}'.format(request.unit_name))
-        if not request.has_credentials:
-            creds = layer.vsphere.get_user_credentials()
-            request.set_credentials(**creds)
+        creds = layer.vsphere.get_vsphere_credentials()
+        config = layer.vsphere.get_vsphere_config()
+
+        request.set_credentials(**creds)
+        request.set_config(**config)
         layer.vsphere.log('Finished request for {}', request.unit_name)
     clients.mark_completed()
 


### PR DESCRIPTION
- readme cleanup
- only use individual config for creds if *all* opts are set
- new folder/respool_path config
- split credential and config handling
- update clients on config-changed