### PR TITLE
upgrade integration tests to test storage and provider_ids

### DIFF
--- a/tests/data/bind_pvc.yaml
+++ b/tests/data/bind_pvc.yaml
@@ -1,12 +1,3 @@
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: mystorage
-provisioner: kubernetes.io/vsphere-volume
-parameters:
-  diskformat: zeroedthick
----
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
@@ -17,7 +8,6 @@ spec:
   resources:
     requests:
       storage: 100Mi
-  storageClassName: mystorage
 ---
 apiVersion: v1
 kind: Pod
@@ -26,7 +16,7 @@ metadata:
   namespace: default
 spec:
   containers:
-    - image: busybox
+    - image: rocks.canonical.com/cdk/busybox:1.36
       command:
         - sleep
         - "3600"

--- a/tests/data/charm.yaml
+++ b/tests/data/charm.yaml
@@ -12,6 +12,10 @@ applications:
       datastore: {{ datastore }}
     num_units: 1
     trust: true
+  vsphere-cloud-provider:
+    charm: vsphere-cloud-provider
 relations:
-  - ['vsphere-integrator', 'kubernetes-control-plane']
-  - ['vsphere-integrator', 'kubernetes-worker']
+- [vsphere-cloud-provider:certificates, easyrsa:client]
+- [vsphere-cloud-provider:kube-control, kubernetes-control-plane:kube-control]
+- [vsphere-cloud-provider:external-cloud-provider, kubernetes-control-plane:external-cloud-provider]
+- [vsphere-cloud-provider:vsphere-integration, vsphere-integrator:clients]

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ deps =
     lightkube
 commands =
     pytest --tb native \
+        --asyncio-mode=auto \
         --show-capture=no \
         --disable-pytest-warnings \
         --log-cli-level=INFO \


### PR DESCRIPTION
This PR modernizes the integration testing
1) Uses juju 3.1 
ex)  'juju ~~run~~ exec'
2) Uses vsphere-cloud-provider now that this testing is completly past kubernetes 1.25
3) No longer operates with existing models where an application may be named `kubernetes-master`
4) Updates the PVC test to not create a storage class (that's done with the vsphere-cloud-provider)
5) Updates the tests to include the pytest `async-mode=auto`